### PR TITLE
Add `omit_import_id` parameter to webhook classes

### DIFF
--- a/lib/f2ynab/version.rb
+++ b/lib/f2ynab/version.rb
@@ -1,3 +1,3 @@
 module F2ynab
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/f2ynab/webhooks/monzo.rb
+++ b/lib/f2ynab/webhooks/monzo.rb
@@ -1,12 +1,13 @@
 module F2ynab
   module Webhooks
     class Monzo
-      def initialize(ynab_client, webhook, skip_tags: false, skip_foreign_currency_flag: false, skip_emoji: false)
+      def initialize(ynab_client, webhook, skip_tags: false, skip_foreign_currency_flag: false, skip_emoji: false, omit_import_id: false)
         @ynab_client = ynab_client
         @webhook = webhook
         @skip_tags = skip_tags
         @skip_foreign_currency_flag = skip_foreign_currency_flag
         @skip_emoji = skip_emoji
+        @omit_import_id = omit_import_id
       end
 
       def import
@@ -44,7 +45,7 @@ module F2ynab
 
         ::F2ynab::YNAB::TransactionCreator.new(
           @ynab_client,
-          id: @webhook[:data][:id],
+          id: @omit_import_id ? nil : @webhook[:data][:id],
           date: Time.parse(@webhook[:data][:created]).to_date,
           amount: @webhook[:data][:amount] * 10,
           payee_name: payee_name,

--- a/lib/f2ynab/webhooks/starling.rb
+++ b/lib/f2ynab/webhooks/starling.rb
@@ -29,10 +29,11 @@ module F2ynab
         INTEREST_CHARGE
       ]
 
-      def initialize(ynab_client, webhook, skip_foreign_currency_flag: false)
+      def initialize(ynab_client, webhook, skip_foreign_currency_flag: false, omit_import_id: false)
         @webhook = webhook
         @ynab_client = ynab_client
         @skip_foreign_currency_flag = skip_foreign_currency_flag
+        @omit_import_id = omit_import_id
       end
 
       def import
@@ -54,7 +55,7 @@ module F2ynab
 
         ::F2ynab::YNAB::TransactionCreator.new(
           @ynab_client,
-          id: "S:#{@webhook[:content][:transactionUid]}",
+          id: @omit_import_id ? nil : "S:#{@webhook[:content][:transactionUid]}",
           date: Time.parse(@webhook[:timestamp]).to_date,
           amount: amount,
           payee_name: payee_name,

--- a/lib/f2ynab/ynab/client.rb
+++ b/lib/f2ynab/ynab/client.rb
@@ -28,19 +28,21 @@ module F2ynab
       end
 
       def create_transaction(id: nil, payee_id: nil, payee_name: nil, amount: nil, cleared: nil, date: nil, memo: nil, flag: nil)
+        transaction_params = {
+          account_id: selected_account_id,
+          date: date.to_s,
+          amount: amount,
+          payee_id: payee_id,
+          payee_name: payee_name,
+          cleared: cleared ? "Cleared" : 'Uncleared',
+          memo: memo,
+          flag_color: flag,
+        }
+        transaction_params[:import_id] = id unless id.nil? || id.empty?
+
         client.transactions.create_transaction(
           selected_budget_id,
-          transaction: {
-            account_id: selected_account_id,
-            date: date.to_s,
-            amount: amount,
-            payee_id: payee_id,
-            payee_name: payee_name,
-            cleared: cleared ? "Cleared" : 'Uncleared',
-            memo: memo,
-            flag_color: flag,
-            import_id: id,
-          },
+          transaction: transaction_params,
         ).data.transaction
       rescue StandardError => e
         Rails.logger.error('YNAB::Client.create_transaction failure')


### PR DESCRIPTION
Add a new `omit_import_id` parameter to Monzo and Starling webhook classes to support creating user-entered transactions instead of imported transactions.

When `omit_import_id: true`:
  - TransactionCreator receives nil as import_id
  - YNAB API treats transaction as user-entered
  - Transaction becomes eligible for matching against future imports

This satisfies YNAB API requirements where omitted/null `import_id` creates user-entered transactions that can be matched against imported transactions with same amount and date (±10 days). This allows the use of the direct import feature alongside webhooks.

Changes:
  - F2ynab::Webhooks::Monzo: Added `omit_import_id` parameter and conditional logic
  - F2ynab::Webhooks::Starling: Added `omit_import_id` parameter and conditional logic
  - Both classes default to `omit_import_id: false` to maintain existing behaviour